### PR TITLE
improved error handling

### DIFF
--- a/includes/MintyDocsPublishAction.php
+++ b/includes/MintyDocsPublishAction.php
@@ -44,7 +44,7 @@ class MintyDocsPublishAction extends Action {
 
 		$mdPage = MintyDocsUtils::pageFactory( $title );
 		$user = $obj->getUser();
-		if ( !$mdPage->userCanAdminister( $user ) ) {
+		if ( !empty($mdPage) && !$mdPage->userCanAdminister( $user ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
An error/typo in page wikitext can cause 500 error due to page not being recognized as MintyDocs. 
Adding an empty check on line 47 is minimal overhead and ensures page doesn't become inaccessible.