### PR TITLE
Add support for publishing long pages via jobs

### DIFF
--- a/includes/MintyDocsCreatePageJob.php
+++ b/includes/MintyDocsCreatePageJob.php
@@ -33,7 +33,13 @@ class MintyDocsCreatePageJob extends Job {
 			}
 		}
 
-		$pageText = $this->params['page_text'];
+		if ( $this->params['long_page'] ) {
+			$fromPage = WikiPage::factory( $this->params['page_source'] );
+			$pageText = $fromPage->getContent()->getNativeData();
+		}
+		else {
+			$pageText = $this->params['page_text'];
+		}
 		$editSummary = '';
 		if ( array_key_exists( 'edit_summary', $this->params ) ) {
 			$editSummary = $this->params['edit_summary'];

--- a/includes/specials/MintyDocsPublish.php
+++ b/includes/specials/MintyDocsPublish.php
@@ -359,6 +359,14 @@ class MintyDocsPublish extends SpecialPage {
 				}
 			}
 
+			$params['page_source'] = $fromTitle;
+			$params['long_page'] = false;
+			if ( strlen(serialize((array)$params)) >= 65535 ) {
+				// if size of array exceeds db blob size, job creation fails; handle differently
+				$params['long_page'] = true;
+				$params['page_text'] = "";
+			}
+
 			$jobs[] = new MintyDocsCreatePageJob( $toTitle, $params );
 		}
 


### PR DESCRIPTION
When publishing content, MDCreatePage job creation will fail for large pages due to database field size limitations (blob). 
To avoid this, add a size check for the params array and handle the job slightly differently if working with pages too large to store text in job record.

Note: Edits that take place on large pages after the publish action but before jobs are run could create problems with this method. One alternate approach that could be used is to use MintyDocsUtils::createOrModifyPage directly (after checking that required parent page exists) for large pages instead of storing as a job at all. For wikis with low-volume edits like ours, it seemed better to stay consistent with the job model.